### PR TITLE
Add facebook for keyword rule

### DIFF
--- a/template/ss_gfwlist_conf
+++ b/template/ss_gfwlist_conf
@@ -14,6 +14,8 @@ DOMAIN-KEYWORD,google,Proxy,force-remote-dns
 DOMAIN-KEYWORD,blogspot,Proxy,force-remote-dns
 //for BBC 
 DOMAIN-KEYWORD,bbc,Proxy,force-remote-dns
+//for Facebook
+DOMAIN-KEYWORD,facebook,Proxy,force-remote-dns
 
 // AD Block
 __ADBLOCK__


### PR DESCRIPTION
Facebook is GFW keyword, so we add facebook here.

facebook.design is blocked because of GFW keyword.

gfwlist hasn't add facebook.design.