### PR TITLE
Move `💊DIRECT` to the end of Proxy select list

### DIFF
--- a/ServerConfig.txt
+++ b/ServerConfig.txt
@@ -7,8 +7,7 @@
 
 [Proxy Group]
 ChinaProxy = select,💊DIRECT,🇭🇰HK,🇸🇬SG,🇯🇵JP,🇺🇸US
-Proxy = select,💊DIRECT,🇭🇰HK,🇸🇬SG,🇯🇵JP,🇺🇸US
-
+Proxy = select,🇭🇰HK,🇸🇬SG,🇯🇵JP,🇺🇸US,💊DIRECT
 
 @Auto = url-test,🇭🇰HK,🇸🇬SG,🇯🇵JP,🇺🇸US,url=http://www.gstatic.com/generate_204
-Proxy = select,💊DIRECT,@Auto,🇭🇰HK,🇸🇬SG,🇯🇵JP,🇺🇸US
+Proxy = select,@Auto,🇭🇰HK,🇸🇬SG,🇯🇵JP,🇺🇸US,💊DIRECT


### PR DESCRIPTION
When surge restart due to a configuration update, The Proxy select list will delegate to the first item unless you explicitly select one proxy item. So Surge will select `💊DIRECT` for the `Proxy` group after configuration update. It will probably fail on normal usage.

After this commit, Surge will select `@Auto` as default proxy item.