### PR TITLE
add proxy rules for linkedin.com in geoip_whitelist.conf 

### DIFF
--- a/geoip_whitelist.conf
+++ b/geoip_whitelist.conf
@@ -19,6 +19,8 @@ Proxy = select,@Auto,🇭🇰HK,🇸🇬SG,🇯🇵JP,🇺🇸US
 
 
 [Rule]
+// For linkedin.com
+DOMAIN-SUFFIX,linkedin.com,Proxy
 // For zhihu
 DOMAIN-SUFFIX,oia.zhihu.com,REJECT
 // For tw


### PR DESCRIPTION
- to solve LinkedIn can not be accessed or redirected to linkedin.cn in it's app or website
