### PR TITLE
add proxy rules for linkedin.com static resource url in geoip_whitelist.conf

### DIFF
--- a/geoip_whitelist.conf
+++ b/geoip_whitelist.conf
@@ -21,6 +21,7 @@ Proxy = select,@Auto,🇭🇰HK,🇸🇬SG,🇯🇵JP,🇺🇸US
 [Rule]
 // For linkedin.com
 DOMAIN-SUFFIX,linkedin.com,Proxy
+DOMAIN-SUFFIX,licdn.com,Proxy
 // For zhihu
 DOMAIN-SUFFIX,oia.zhihu.com,REJECT
 // For tw


### PR DESCRIPTION
- avoid keeping the reloading status when using the web version of Linkedin.com