### PR TITLE
add the url of Apple Podcast's data cache

### DIFF
--- a/template/ss_geoip_white_conf
+++ b/template/ss_geoip_white_conf
@@ -16,6 +16,7 @@ DOMAIN-SUFFIX,oia.zhihu.com,REJECT
 // For tw
 DOMAIN-SUFFIX,tw,Proxy
 // For apple inc
+DOMAIN-SUFFIX,stitcher.simplecastaudio.com,Proxy
 DOMAIN-SUFFIX,appstoreconnect.apple.com,Proxy
 DOMAIN-SUFFIX,contentdelivery.itunes.apple.com,Proxy
 DOMAIN-SUFFIX,itmsdav.apple.com,Proxy

--- a/template/ss_gfwlist_conf
+++ b/template/ss_gfwlist_conf
@@ -16,6 +16,7 @@ DOMAIN-SUFFIX,oia.zhihu.com,REJECT
 // For tw
 DOMAIN-SUFFIX,tw,Proxy
 // For apple inc
+DOMAIN-SUFFIX,stitcher.simplecastaudio.com,Proxy
 DOMAIN-SUFFIX,appstoreconnect.apple.com,Proxy
 DOMAIN-SUFFIX,contentdelivery.itunes.apple.com,Proxy
 DOMAIN-SUFFIX,itmsdav.apple.com,Proxy

--- a/template/ss_whitelist_conf
+++ b/template/ss_whitelist_conf
@@ -16,6 +16,7 @@ DOMAIN-SUFFIX,oia.zhihu.com,REJECT
 // For tw
 DOMAIN-SUFFIX,tw,Proxy
 // For apple inc
+DOMAIN-SUFFIX,stitcher.simplecastaudio.com,Proxy
 DOMAIN-SUFFIX,appstoreconnect.apple.com,Proxy
 DOMAIN-SUFFIX,contentdelivery.itunes.apple.com,Proxy
 DOMAIN-SUFFIX,itmsdav.apple.com,Proxy


### PR DESCRIPTION
- make Apple podcast's data loading fast
![1702397076148](https://github.com/R0uter/ss.conf-for-surge/assets/18098166/9f1fb3a7-e871-485c-913f-8869d9bcc8ac)
